### PR TITLE
[Feature/#1] auditing 적용: base entity 생성

### DIFF
--- a/src/main/java/algo_arena/AlgoArenaApplication.java
+++ b/src/main/java/algo_arena/AlgoArenaApplication.java
@@ -2,12 +2,22 @@ package algo_arena;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AlgoArenaApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(AlgoArenaApplication.class, args);
+	}
+
+	@Bean
+	public AuditorAware<String> auditorProvider() {
+		//TODO: 세션정보 or 스프링 시큐리티 로그인 정보에서 id 받기
+		return null;
 	}
 
 }

--- a/src/main/java/algo_arena/common/entity/BaseEntity.java
+++ b/src/main/java/algo_arena/common/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package algo_arena.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private String lastModifiedBy;
+}

--- a/src/main/java/algo_arena/common/entity/BaseTimeEntity.java
+++ b/src/main/java/algo_arena/common/entity/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package algo_arena.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime lastModifiedDate;
+}


### PR DESCRIPTION
# Pull Request

## 작업 내용
- 스프링 데이터 auditing 기능 적용
- 스프링 부트 클래스 및 base entity auditing 설정

## 관련 이슈
close #1

## 기타 참고 사항
### ✅ base entity 이중 설계
엔티티에 따라 시간과 인증 정보가 모두 필요한 경우도 있지만, 시간 정보만 필요한 경우도 있음을 고려하였습니다.
우선, 시간 정보를 추적하는 `BaseTimeEntity` 클래스를 구현한 후, 이를 상속하여 인증 정보까지 추가로 추적하는 `BaseEntity` 클래스를 구현하여 엔티티의 특성에 맞게 선택적으로 상속받을 수 있도록 이중으로 구현하였습니다.
```
BaseTimeEntity(시간 정보만 추적) <- BaseEntity(+ 인증 정보까지 추적)
```